### PR TITLE
Change tile formation

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -1,25 +1,28 @@
 function setup() {
   createCanvas(700, 700);
-  number_of_tiles = 10;
+  let c1 = color(145, 145, 30)
+  let c2 = color(30, 165, 80)
+  number_of_tiles = 30;
   size = width / number_of_tiles;
   background(255)
   strokeWeight(2);
-  for (x = 0; x < number_of_tiles + 1; x++) {
-    for (y = 0; y < number_of_tiles + 1; y++) {
+
+  for (x = 1; x < number_of_tiles - 1; x++) {
+    for (y = 1; y < number_of_tiles - 1; y++) {
       push();
       // translate(i * size, j * size);
-      let xpos = x * 70
-      let ypos = y * 70
-      // if (random(0, 2) < .3){
-      //   draw_lines(xpos, ypos);
-      // } else {
-      //   draw_curves(xpos, ypos);
-      // }
-      // stroke(155, 155, 155)
-      rect(xpos, ypos, size, size)
-      draw_circs(xpos, ypos)
-      // stroke(0)
-      // draw_lines(xpos, ypos)
+      let xpos = x * size
+      let ypos = y * size
+      strokeWeight(4)
+      stroke(c2)
+      which_to_draw = random(0, 3)
+      if (which_to_draw < 1) {
+        draw_circs(xpos, ypos);
+      } else if (which_to_draw < 2.7) {
+        draw_curves(xpos, ypos);
+      } else {
+        draw_lines(xpos, ypos)
+      }
       pop();
     }
   }
@@ -29,29 +32,16 @@ function draw() {
 }
 
 function draw_curves(xpos, ypos) {
-  // translate(xpos + (size / 2), ypos + (size / 2))
-  // rotate(floor(random(4)) * PI * 0.5)
-  // translate(-xpos, -ypos)
-  // fill(0);
-  // strokeWeight(4)
-  arc1 = arc(xpos, ypos, size, size, PI * 0.5, PI)
-  arc2 = arc(xpos, ypos, size, size, -PI * 0.5, 0)
-  return arc1
+  arc1 = arc(xpos, ypos + size, size, size, -HALF_PI, 0)
+  arc2 = arc(xpos + size, ypos, size, size, HALF_PI, PI)
 }
 
 function draw_circs(xpos, ypos) {
-  translate(xpos + (size / 2), ypos + (size / 2))
-  rotate(floor(random(2)) * PI * 0.5)
-  translate(-xpos, -ypos)
-  // fill(0);
-  // strokeWeight(4)
-  arc1 = arc(xpos, ypos, size, size, PI * 0.5, PI)
-  arc2 = arc(xpos, ypos, size, size, -PI * 0.5, 0)
-  return arc1
+  arc1 = arc(xpos, ypos, size, size, 0, HALF_PI)
+  arc2 = arc(xpos + size, ypos + size, size, size, PI, -HALF_PI)
 }
 
 function draw_lines(xpos, ypos) {
-  line1 = line(xpos + (size /2), ypos, xpos + (size /2), ypos + size);
-  line2 = line(xpos, ypos + (size /2), xpos + size, ypos + (size / 2));
-  return line1, line2
+  line1 = line(xpos + (size / 2), ypos, xpos + (size / 2), ypos + size);
+  line2 = line(xpos, ypos + (size / 2), xpos + size, ypos + (size / 2));
 }

--- a/sketch.js
+++ b/sketch.js
@@ -1,20 +1,23 @@
+let grid = []
+let bg
+let c1
+let strk = 6
+
 function setup() {
   createCanvas(700, 700);
-  let c1 = color(145, 145, 30)
-  let c2 = color(30, 165, 80)
-  number_of_tiles = 30;
+  c1 = color(30, 165, 80)
+  number_of_tiles = 20;
   size = width / number_of_tiles;
-  background(255)
-  strokeWeight(2);
-
+  bg = color(255)
+  background(bg)
   for (x = 1; x < number_of_tiles - 1; x++) {
     for (y = 1; y < number_of_tiles - 1; y++) {
-      push();
       // translate(i * size, j * size);
       let xpos = x * size
       let ypos = y * size
-      strokeWeight(4)
-      stroke(c2)
+      grid.push([xpos, ypos])
+      strokeWeight(strk)
+      stroke(c1)
       which_to_draw = random(0, 3)
       if (which_to_draw < 1) {
         draw_circs(xpos, ypos);
@@ -23,12 +26,31 @@ function setup() {
       } else {
         draw_lines(xpos, ypos)
       }
-      pop();
     }
   }
 }
 
+let i = 0;
+
 function draw() {
+  frameRate(22)
+  let one_to_change = i++ % grid.length
+  xpos = grid[one_to_change][0]
+  ypos = grid[one_to_change][1]
+  fill(bg)
+  noStroke()
+  rect(xpos, ypos, size, size)
+  strokeWeight(strk)
+  stroke(c1)
+  which_to_draw = random(0, 3)
+  if (which_to_draw < 1) {
+    draw_circs(xpos, ypos);
+  } else if (which_to_draw < 2.7) {
+    draw_curves(grid[one_to_change][0], grid[one_to_change][1]);
+  } else {
+    draw_lines(grid[one_to_change][0], grid[one_to_change][1]);
+  }
+
 }
 
 function draw_curves(xpos, ypos) {

--- a/sketch.js
+++ b/sketch.js
@@ -1,27 +1,25 @@
 function setup() {
-  createCanvas(400, 400);
-  number_of_tiles = 13;
+  createCanvas(700, 700);
+  number_of_tiles = 10;
   size = width / number_of_tiles;
   background(255)
   strokeWeight(2);
-  for (i = 0; i < number_of_tiles + 1; i++) {
-    for (j = 0; j < number_of_tiles + 1; j ++) {
+  for (x = 0; x < number_of_tiles + 1; x++) {
+    for (y = 0; y < number_of_tiles + 1; y++) {
       push();
-      translate(i * size, j * size);
-      centerPoint = new p5.Vector(size/2, size/2);
-      rotate(floor(random(4)) * PI * 0.5, centerPoint);
-      if (random(0, 2) < .3){
-        lines = draw_lines();
-        
-      } else {
-        draw_curves();
-      }
-      // draw_lines();
-
-      stroke(220, 0, 0);
-      strokeWeight(5);
-      noFill()
-      // square(0,0,size);
+      // translate(i * size, j * size);
+      let xpos = x * 70
+      let ypos = y * 70
+      // if (random(0, 2) < .3){
+      //   draw_lines(xpos, ypos);
+      // } else {
+      //   draw_curves(xpos, ypos);
+      // }
+      // stroke(155, 155, 155)
+      rect(xpos, ypos, size, size)
+      draw_circs(xpos, ypos)
+      // stroke(0)
+      // draw_lines(xpos, ypos)
       pop();
     }
   }
@@ -30,15 +28,30 @@ function setup() {
 function draw() {
 }
 
-function draw_curves() {
-  fill(0);
-  arc1 = arc(size/2, -size/2, size, size, PI * 0.5, PI)
-  arc2 = arc(-size/2, size/2, size, size, -PI * 0.5, 0)
-  return arc1, arc2
+function draw_curves(xpos, ypos) {
+  // translate(xpos + (size / 2), ypos + (size / 2))
+  // rotate(floor(random(4)) * PI * 0.5)
+  // translate(-xpos, -ypos)
+  // fill(0);
+  // strokeWeight(4)
+  arc1 = arc(xpos, ypos, size, size, PI * 0.5, PI)
+  arc2 = arc(xpos, ypos, size, size, -PI * 0.5, 0)
+  return arc1
 }
 
-function draw_lines() {
-  line1 = line(-size / 2, 0, size / 2, 0);
-  line2 = line(0, -size / 2, 0, size / 2);
+function draw_circs(xpos, ypos) {
+  translate(xpos + (size / 2), ypos + (size / 2))
+  rotate(floor(random(2)) * PI * 0.5)
+  translate(-xpos, -ypos)
+  // fill(0);
+  // strokeWeight(4)
+  arc1 = arc(xpos, ypos, size, size, PI * 0.5, PI)
+  arc2 = arc(xpos, ypos, size, size, -PI * 0.5, 0)
+  return arc1
+}
+
+function draw_lines(xpos, ypos) {
+  line1 = line(xpos + (size /2), ypos, xpos + (size /2), ypos + size);
+  line2 = line(xpos, ypos + (size /2), xpos + size, ypos + (size / 2));
   return line1, line2
 }


### PR DESCRIPTION
Improved method of determining position and drawing different tiles- instead of translating position, calls are made to draw curves/lines directly based on x/y position of grid squares. These coordinates are stored in an array. This improved seamless rendering of lines. Rotating tiles without them breaking the grid proved too difficult to feel worth it, so different orientations were handled with separate functions to draw the appropriate arcs. 
Additionally, now draw() updates the tile in the locations in the grid array, looping through it and assigning a new random tile. This allows a project to stay dynamic rather than rendering a single static image on load. I may add a toggle for this. 